### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn lagrange_string_interp(s: &str) -> String {
             .for_each(|(_, xj)| {
                 match *xj == 0 {
                     true => numerator += "x*",
-                    false => numerator += &format!("(x-{:.}.0)*", xj),
+                    false => numerator += &format!("(x-{}.0)*", xj),
                 };
                 denominator *= x - xj
             });
@@ -41,9 +41,9 @@ fn lagrange_string_interp(s: &str) -> String {
         match y == one {
             true => result += &numerator,
             false if y.rem_trunc_ref().complete().cmp0() == Ordering::Equal => {
-                result += &format!("{:.}.0*{:.}", y.to_f64(), numerator)
+                result += &format!("{}.0*{}", y.to_f64(), numerator)
             }
-            _ => result += &format!("{:.}*{:.}", y.to_f64(), numerator),
+            _ => result += &format!("{}*{}", y.to_f64(), numerator),
         }
         numerator.clear()
     }


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.